### PR TITLE
Add NetworkInfo tests

### DIFF
--- a/Model.Tests/Model.Tests.csproj
+++ b/Model.Tests/Model.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Model\Model.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Model.Tests/NetworkInfoTests.cs
+++ b/Model.Tests/NetworkInfoTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Model;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Timers;
+
+namespace Model.Tests
+{
+    [TestClass]
+    public class NetworkInfoTests
+    {
+        [TestMethod]
+        public void CalculatesInboundOutboundSpeedCorrectly()
+        {
+            var ni = new NetworkInfo();
+
+            // Stop internal timer to avoid interference
+            var timerField = typeof(NetworkInfo).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance);
+            var timer = (System.Timers.Timer)timerField!.GetValue(ni)!;
+            timer.Stop();
+
+            var inboundField = typeof(NetworkInfo).GetField("inboundTraffic", BindingFlags.NonPublic | BindingFlags.Instance);
+            var outboundField = typeof(NetworkInfo).GetField("outboundTraffic", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var inboundList = (List<long>)inboundField!.GetValue(ni)!;
+            var outboundList = (List<long>)outboundField!.GetValue(ni)!;
+            inboundList.Clear();
+            outboundList.Clear();
+
+            // Set predetermined traffic samples
+            inboundList.AddRange(new long[] { 1000, 2000, 3000 });
+            outboundList.AddRange(new long[] { 500, 1500, 2500 });
+
+            var inboundSpeedProp = typeof(NetworkInfo).GetProperty("InboundSpeed", BindingFlags.NonPublic | BindingFlags.Instance);
+            var outboundSpeedProp = typeof(NetworkInfo).GetProperty("OutboundSpeed", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            long inboundSpeed = (long)inboundSpeedProp!.GetValue(ni)!;
+            long outboundSpeed = (long)outboundSpeedProp!.GetValue(ni)!;
+
+            Assert.AreEqual(666, inboundSpeed);
+            Assert.AreEqual(666, outboundSpeed);
+        }
+    }
+}

--- a/Model/Properties/AssemblyInfo.cs
+++ b/Model/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("Model.Tests")]

--- a/WindowsSleepAssist/WindowsSleepAssist.sln
+++ b/WindowsSleepAssist/WindowsSleepAssist.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsSleepAssistService",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WcfInterface", "..\WcfInterface\WcfInterface.csproj", "{66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Model.Tests", "..\Model.Tests\Model.Tests.csproj", "{055BA9C0-DA82-4675-A252-4021C569DF2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,10 +32,14 @@ Global
 		{3B43B33E-7B47-4646-80FB-40B2703A5200}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B43B33E-7B47-4646-80FB-40B2703A5200}.Release|Any CPU.Build.0 = Release|Any CPU
 		{66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {66DE1DDF-7CFC-41E6-8D28-3E8CBE265ADF}.Release|Any CPU.Build.0 = Release|Any CPU
+                {055BA9C0-DA82-4675-A252-4021C569DF2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {055BA9C0-DA82-4675-A252-4021C569DF2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {055BA9C0-DA82-4675-A252-4021C569DF2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {055BA9C0-DA82-4675-A252-4021C569DF2B}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add MSTest project
- expose internals of `Model` for testing
- test NetworkInfo speed calculation
- add test project to solution

## Testing
- `FrameworkPathOverride=/usr/lib/mono/4.5 dotnet test WindowsSleepAssist/WindowsSleepAssist.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855c9f8ef04832b826df1df3a13d544